### PR TITLE
fix for issue #8

### DIFF
--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -3561,7 +3561,7 @@ def calibrateandapplycal(mslist, selfcalcycle, args, solint_list, nchan_list, \
    print(parmdbmergelist)
    #try:
    if True:
-     #import h5_merger
+     import h5_merger
      for msnumber, ms in enumerate(mslist):
        if skymodel != None and selfcalcycle == 0: 
          parmdbmergename = 'merged_skyselfcalcyle' + str(selfcalcycle).zfill(3) + '_' + ms + '.h5'

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4223,6 +4223,12 @@ def main():
 
    args = vars(parser.parse_args())
 
+   options = parser.parse_args() # start of replacing args dictionary with objects options
+   #print (options.preapplyH5_list)
+
+   print( 'options before' )
+   print( options )
+
    ## if a config file exists, then read the information
    if os.path.isfile('facetselfcal_config.txt'):
       print( 'A config file exists, using it. This contains:' )
@@ -4239,10 +4245,10 @@ def main():
          except:
             lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
-         args[line.split('=')[0].rstrip()] = lineval
+         options[line.split('=')[0].rstrip()] = lineval
 
-   options = parser.parse_args() # start of replacing args dictionary with objects options
-   #print (options.preapplyH5_list)
+   print( 'options after' )
+   print( options )
 
    version = '3.2.0'
    print_title(version)

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4224,9 +4224,11 @@ def main():
    args = vars(parser.parse_args())
    ## if a config file exists, then read the information
    if os.path.isfile('facetselfcal_config.txt'):
+      print( 'A config file exists, using it. This contains:' )
       with open('facetselfcal_config.txt','r') as f:
          lines = f.readlines()
       for line in lines:
+         print( line )
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = line.split('=')[1].lstrip().rstrip('\n')
 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4222,6 +4222,9 @@ def main():
    parser.add_argument('ms', nargs='+', help='msfile(s)')  
 
    args = vars(parser.parse_args())
+   print( 'args before:' )
+   print( args )
+   
    ## if a config file exists, then read the information
    if os.path.isfile('facetselfcal_config.txt'):
       print( 'A config file exists, using it. This contains:' )
@@ -4231,6 +4234,9 @@ def main():
          print( line )
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = line.split('=')[1].lstrip().rstrip('\n')
+         
+   print( 'args after:' )
+   print( args )
 
    options = parser.parse_args() # start of replacing args dictionary with objects options
    #print (options.preapplyH5_list)

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4256,8 +4256,8 @@ def main():
    print_title(version)
 
    os.system('cp ' + args['helperscriptspath'] + '/lib_multiproc.py .')
-   if args['helperscriptspath-h5merge'] != None:
-     os.system('cp ' + args['helperscriptspath-h5merge'] + '/h5_merger.py .')  
+   if args['helperscriptspath_h5merge'] != None:
+     os.system('cp ' + args['helperscriptspath_h5merge'] + '/h5_merger.py .')  
    else:
      os.system('cp ' + args['helperscriptspath'] + '/h5_merger.py .')
    os.system('cp ' + args['helperscriptspath'] + '/plot_tecandphase.py .')

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4222,6 +4222,14 @@ def main():
    parser.add_argument('ms', nargs='+', help='msfile(s)')  
 
    args = vars(parser.parse_args())
+   ## if a config file exists, then read the information
+   if os.path.isfile('facetselfcal_config.txt'):
+      with open('facetselfcal_config.txt','r') as f:
+         lines = f.readlines()
+      for line in lines:
+         ## this updates the vaue if it exists, or creates a new one if it doesn't
+         args[line.split('=')[0].rstrip()] = line.split('=')[1].lstrip().rstrip('\n')
+
    options = parser.parse_args() # start of replacing args dictionary with objects options
    #print (options.preapplyH5_list)
 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -62,6 +62,7 @@ from itertools import product
 import subprocess
 import matplotlib.pyplot as plt
 from astropy.wcs import WCS
+import h5_merger
 
 #from astropy.utils.data import clear_download_cache
 #clear_download_cache()
@@ -4267,7 +4268,7 @@ def main():
 
    inputchecker(args)
    check_code_is_uptodate()
-   import h5_merger
+   #import h5_merger
 
    for h5parm_id, h5parm in enumerate(args['preapplyH5_list']):
      if h5parm != None:

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4222,9 +4222,7 @@ def main():
    parser.add_argument('ms', nargs='+', help='msfile(s)')  
 
    args = vars(parser.parse_args())
-   print( 'args before:' )
-   print( args )
-   
+
    ## if a config file exists, then read the information
    if os.path.isfile('facetselfcal_config.txt'):
       print( 'A config file exists, using it. This contains:' )
@@ -4242,9 +4240,6 @@ def main():
             lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = lineval
-         
-   print( 'args after:' )
-   print( args )
 
    options = parser.parse_args() # start of replacing args dictionary with objects options
    #print (options.preapplyH5_list)

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -3561,7 +3561,7 @@ def calibrateandapplycal(mslist, selfcalcycle, args, solint_list, nchan_list, \
    print(parmdbmergelist)
    #try:
    if True:
-     import h5_merger
+     #import h5_merger
      for msnumber, ms in enumerate(mslist):
        if skymodel != None and selfcalcycle == 0: 
          parmdbmergename = 'merged_skyselfcalcyle' + str(selfcalcycle).zfill(3) + '_' + ms + '.h5'
@@ -4267,7 +4267,7 @@ def main():
 
    inputchecker(args)
    check_code_is_uptodate()
-   
+   import h5_merger
 
    for h5parm_id, h5parm in enumerate(args['preapplyH5_list']):
      if h5parm != None:

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4221,13 +4221,15 @@ def main():
   
    parser.add_argument('ms', nargs='+', help='msfile(s)')  
 
+
+
    args = vars(parser.parse_args())
 
    options = parser.parse_args() # start of replacing args dictionary with objects options
    #print (options.preapplyH5_list)
 
-   print( 'options before' )
-   print( options )
+   print( 'args before' )
+   print ( args )
 
    ## if a config file exists, then read the information
    if os.path.isfile('facetselfcal_config.txt'):
@@ -4245,10 +4247,10 @@ def main():
          except:
             lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
-         options[line.split('=')[0].rstrip()] = lineval
+         args[line.split('=')[0].rstrip()] = lineval
 
-   print( 'options after' )
-   print( options )
+   print( 'args after' )
+   print( args )
 
    version = '3.2.0'
    print_title(version)

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -62,7 +62,6 @@ from itertools import product
 import subprocess
 import matplotlib.pyplot as plt
 from astropy.wcs import WCS
-import h5_merger
 
 #from astropy.utils.data import clear_download_cache
 #clear_download_cache()
@@ -4262,6 +4261,8 @@ def main():
      os.system('cp ' + args['helperscriptspath_h5merge'] + '/h5_merger.py .')  
    else:
      os.system('cp ' + args['helperscriptspath'] + '/h5_merger.py .')
+   sys.path.append(os.path.abspath(args['helperscriptspath_h5merge']))
+   import h5_merger
    os.system('cp ' + args['helperscriptspath'] + '/plot_tecandphase.py .')
    os.system('cp ' + args['helperscriptspath'] + '/lin2circ.py .')
    os.system('cp ' + args['helperscriptspath'] + '/BLsmooth.py .')

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4246,7 +4246,7 @@ def main():
 
    os.system('cp ' + args['helperscriptspath'] + '/lib_multiproc.py .')
    if args['helperscriptspath-h5merge'] != None:
-     os.system('cp ' + args['helperscriptspath_h5merge'] + '/h5_merger.py .')  
+     os.system('cp ' + args['helperscriptspath-h5merge'] + '/h5_merger.py .')  
    else:
      os.system('cp ' + args['helperscriptspath'] + '/h5_merger.py .')
    os.system('cp ' + args['helperscriptspath'] + '/plot_tecandphase.py .')

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4245,7 +4245,7 @@ def main():
    print_title(version)
 
    os.system('cp ' + args['helperscriptspath'] + '/lib_multiproc.py .')
-   if args['helperscriptspath_h5merge'] != None:
+   if args['helperscriptspath-h5merge'] != None:
      os.system('cp ' + args['helperscriptspath_h5merge'] + '/h5_merger.py .')  
    else:
      os.system('cp ' + args['helperscriptspath'] + '/h5_merger.py .')

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4232,8 +4232,17 @@ def main():
          lines = f.readlines()
       for line in lines:
          print( line )
+         ## first get the value
+         lineval = line.split('=')[1].lstrip().rstrip('\n')
+         try:
+            lineval = float( lineval )
+            if int(lineval) - lineval == 0:
+               lineval = int(lineval)
+         except:
+            lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
-         args[line.split('=')[0].rstrip()] = line.split('=')[1].lstrip().rstrip('\n')
+        
+         args[line.split('=')[0].rstrip()] = 
          
    print( 'args after:' )
    print( args )

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4245,7 +4245,10 @@ def main():
             if int(lineval) - lineval == 0:
                lineval = int(lineval)
          except:
-            lineval = lineval
+            try:
+               lineval = arg_as_dict(lineval)
+            except:
+               lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = lineval
 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4245,10 +4245,8 @@ def main():
             if int(lineval) - lineval == 0:
                lineval = int(lineval)
          except:
-            try:
-               lineval = arg_as_dict(lineval)
-            except:
-               lineval = lineval
+            if ',' in lineval:
+                lineval = arg_as_list(lineval)
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = lineval
 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4245,7 +4245,7 @@ def main():
             if int(lineval) - lineval == 0:
                lineval = int(lineval)
          except:
-            if ',' in lineval:
+            if '[' in lineval:
                 lineval = arg_as_list(lineval)
          ## this updates the vaue if it exists, or creates a new one if it doesn't
          args[line.split('=')[0].rstrip()] = lineval

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4241,8 +4241,7 @@ def main():
          except:
             lineval = lineval
          ## this updates the vaue if it exists, or creates a new one if it doesn't
-        
-         args[line.split('=')[0].rstrip()] = 
+         args[line.split('=')[0].rstrip()] = lineval
          
    print( 'args after:' )
    print( args )


### PR DESCRIPTION
This is a fix for issue #8 and has been tested now to run in the generic pipeline.  This is done by using a config file (with a specific name) if present, which the wrapper script in the lofar-vlbi pipeline copies into place.  If the config file is present, the contents are read in and any args present in the file are used to update the args in the script.  If the config file is not present, nothing happens.

There is also a fix for adding the helperscriptspath-h5merge path to the pythonpath so the h5_merger script can be imported correctly. 