### PR TITLE
Check the config file for invalid options

### DIFF
--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -5752,7 +5752,10 @@ def main():
             if '[' in lineval:
                 lineval = arg_as_list(lineval)
          # this updates the vaue if it exists, or creates a new one if it doesn't
-         setattr( options, line.split('=')[0].rstrip(), lineval )
+         arg = line.split('=')[0].rstrip()
+         if arg not in vars(options).keys():
+            raise KeyError('Encountered invalid option {:s} in config file {:s}.'.format(arg))
+         setattr( options, arg, lineval )
 
 
    args = vars(options)


### PR DESCRIPTION
Checks the config file for invalid options by comparing it against the list of argparse options.

This will prevent illegal options from sneaking through. For example, specifying `resetsols-list` instead of `resetsols_list` would result in solutions not being reset because of a typo (dash instead of underscore).