### PR TITLE
Fix to code checking 

### DIFF
--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -5804,7 +5804,7 @@ def main():
 
 
    inputchecker(args)
-   if args['helperscriptspathh5merge'] == None:  
+   if args['helperscriptspathh5merge'] is None:  
       check_code_is_uptodate()
 
 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -5804,7 +5804,8 @@ def main():
 
 
    inputchecker(args)
-   check_code_is_uptodate()
+   if args['helperscriptspathh5merge'] == None:  
+      check_code_is_uptodate()
 
 
    for h5parm_id, h5parmdb in enumerate(args['preapplyH5_list']):

--- a/selfcal.log
+++ b/selfcal.log
@@ -1,1 +1,0 @@
-WARNING:02/27/2023 14:28:24 ---- Failed to import EveryBeam, functionality will not be available.

--- a/selfcal.log
+++ b/selfcal.log
@@ -1,0 +1,1 @@
+WARNING:02/27/2023 14:28:24 ---- Failed to import EveryBeam, functionality will not be available.


### PR DESCRIPTION
Have added a quick check to whether the h5merger path has been specified. If it has then we do not attempt to download the latest code. 

This is in reference to #53 