### PR TITLE
bug fix full jones bad values 

### DIFF
--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
 
+# fix RR-LL referencing for flaged solutions, find core stations with the least amount of flagged data
+# put all fits images in images folder, all solutions in solutions folder? to reduce clutter
 # normamps full jones, deal with solnorm on crosshands only? currently normaps not used for fulljones
 # turn of baseline based avg for MeerKAT?
 # DP3 modeldata syntaxt
 # implement idea of phase detrending.
-# do not predict sky second time in pertubation solve?
 # to do: log command into the FITS header
 # BLsmooth not for gain solves opttion
 # BLsmooth constant smooth for gain solves
 # only trigger HBA upper band selection for sources outside the FWHM?
 # if noise goes up stop selfcal
 # make Ateam plot
-
+# use scalarphasediff sols stats for solints? test amplitude stats as well
 
 
 # example:
@@ -5254,7 +5255,7 @@ def calibrateandapplycal(mslist, selfcalcycle, args, solint_list, nchan_list, \
 
        # make LINEAR solutions from CIRCULAR
        if ('scalarphasediff' in soltype_list) or ('scalarphasediffFR' in soltype_list) or docircular:
-         h5_merger.merge_h5(h5_out=parmdbmergename_pc, h5_tables=parmdbmergename, circ2lin=True)
+         h5_merger.merge_h5(h5_out=parmdbmergename_pc, h5_tables=parmdbmergename, circ2lin=True, propagate_flags=True)
          # add CS stations back for superstation
          if mslist_beforephaseup is not None:
            h5_merger.merge_h5(h5_out=parmdbmergename_pc.replace("selfcalcyle",\

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4695,7 +4695,7 @@ def flagbadamps(parmdb, setweightsphases=True):
        if setweightsphases:
           phase = H.root.sol000.phase000.val[:]
           weights_p = H.root.sol000.phase000.val[:]
-          phases[idx] = 0.0
+          phase[idx] = 0.0
           weights_p[idx] = 0.0
           H.root.sol000.phase000.val[:] = phases
           H.root.sol000.phase000.weight[:] = weights_p 

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4699,7 +4699,7 @@ def flagbadamps(parmdb, setweightsphases=True):
           weights_p[idx] = 0.0
           H.root.sol000.phase000.val[:] = phase
           H.root.sol000.phase000.weight[:] = weights_p 
-       H5.close()
+       H.close()
 
 
     if fulljones:

--- a/facetselfcal.py
+++ b/facetselfcal.py
@@ -4697,7 +4697,7 @@ def flagbadamps(parmdb, setweightsphases=True):
           weights_p = H.root.sol000.phase000.val[:]
           phase[idx] = 0.0
           weights_p[idx] = 0.0
-          H.root.sol000.phase000.val[:] = phases
+          H.root.sol000.phase000.val[:] = phase
           H.root.sol000.phase000.weight[:] = weights_p 
        H5.close()
 


### PR DESCRIPTION
Set bad values to amplitude 0.0 for XY/XY in fulljones h5. For example if data was flagged.
Set default uvmin to 20000 for long baseline data. Add some an extra function for testing phase noise statistics. Made switch to scalarcomplex solves for long baseline data more conservative. Some extra logging of reference antenna used. Added --uvmax option.