### PR TITLE
tell facet_selfcal to output stdout and stderr for failed commands

### DIFF
--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -1186,14 +1186,21 @@ def run(command, log=False):
     Args:
         command (str): the command to execute.
     Returns:
-        None
+        retval (int): the return code of the executed process.
     """
     if log:
         print(command)
         logger.info(command)
-    retval = subprocess.call(command, shell=True)
-    if retval != 0:
-        print('FAILED to run ' + command + ': return value is ' + str(retval))
+    process = subprocess.run(command, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, encoding="utf-8")
+    retval = process.returncode
+    stdout = process.stdout
+    stderr = process.stderr
+    if retval!= 0:
+        print("FAILED to run", command)
+        print("return value is", retval)
+        print("stderr is", stderr)
+        print("stdout is", stdout)
         raise Exception(command)
     return retval
 


### PR DESCRIPTION
It seems that facet_selfcal's `run` function doesn't output the `stdout` and `stderr` of failed subprocesses; when facet_selfcal fails I keep finding myself applying this patch. Perhaps it is useful to include it into the main repository?

Thoughts welcome.