### PR TITLE
Disable UVW compression in phaseups

### DIFF
--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -2481,6 +2481,8 @@ def phaseup(msinlist, datacolumn='DATA', superstation='core', start=0, dysco=Tru
         cmd = "DP3 msin=" + ms + " steps=[add,filter] "
         cmd += "msout=" + msout + " msin.datacolumn=" + datacolumn + " "
         cmd += "filter.type=filter filter.remove=True "
+        # Do not set to true: DP3's UVW compression does not work with the StationAdder (yet).
+        cmd += "msout.uvwcompression=False "
         if dysco:
             cmd += "msout.storagemanager=dysco "
             cmd += 'msout.storagemanager.weightbitrate=16 '

--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -2676,6 +2676,8 @@ def average(mslist, freqstep, timestep=None, start=0, msinnchan=None, msinstartc
 
             msout = os.path.basename(msout)
             cmd = 'DP3 msin=' + ms + ' av.type=averager '
+            if check_phaseup_station(ms):
+                cmd += 'msout.uvwcompression=False '
             cmd += 'msout=' + msout + ' msin.weightcolumn=WEIGHT_SPECTRUM '
             cmd += 'msin.datacolumn=' + dataincolumn + ' '
             if dysco:
@@ -2754,6 +2756,8 @@ def average(mslist, freqstep, timestep=None, start=0, msinnchan=None, msinstartc
             msouttmp = ms + '.avgtmp'
             msouttmp = os.path.basename(msouttmp)
             cmd = 'DP3 msin=' + ms + ' av.type=averager '
+            if check_phaseup_station(ms):
+                cmd += 'msout.uvwcompression=False '
             if removeinternational:
                 cmd += ' steps=[f,av] '
                 cmd += " f.type=filter f.baseline='[CR]S*&' f.remove=True "

--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -2986,6 +2986,7 @@ def applycal(ms, inparmdblist, msincol='DATA', msoutcol='CORRECTED_DATA',
 
     cmd = 'DP3 numthreads=' + str(np.min([multiprocessing.cpu_count(), 8])) + ' msin=' + ms
     cmd += ' msout=' + msout + ' '
+    if check_phaseup_station(ms): cmd += 'msout.uvwcompression=False '
     cmd += 'msin.datacolumn=' + msincol + ' '
     if msout == '.':
         cmd += 'msout.datacolumn=' + msoutcol + ' '
@@ -5091,6 +5092,7 @@ def removestartendms(ms, starttime=None, endtime=None, dysco=True):
         os.system('rm -rf ' + ms + '.cuttmp')
 
     cmd = 'DP3 msin=' + ms + ' ' + 'msout=' + ms + '.cut '
+    if check_phaseup_station(ms): cmd += 'msout.uvwcompression=False '
     if dysco:
         cmd += 'msout.storagemanager=dysco '
         cmd += 'msout.storagemanager.weightbitrate=16 '
@@ -5103,6 +5105,7 @@ def removestartendms(ms, starttime=None, endtime=None, dysco=True):
     run(cmd)
 
     cmd = 'DP3 msin=' + ms + ' ' + 'msout=' + ms + '.cuttmp '
+    if check_phaseup_station(ms): cmd += 'msout.uvwcompression=False '
     if dysco:
         cmd += 'msout.storagemanager=dysco '
         cmd += 'msout.storagemanager.weightbitrate=16 '
@@ -5151,6 +5154,7 @@ def archive(mslist, outtarname, regionfile, fitsmask, imagename, dysco=True, mer
         if os.path.isdir(msout):
             os.system('rm -rf ' + msout)
         cmd = 'DP3 numthreads=' + str(multiprocessing.cpu_count()) + ' msin=' + ms + ' msout=' + msout + ' '
+        if check_phaseup_station(ms): cmd += 'msout.uvwcompression=False '
         cmd += 'msin.datacolumn=CORRECTED_DATA steps=[] '
         if dysco:
             cmd += 'msout.storagemanager=dysco '
@@ -8791,6 +8795,7 @@ def beamcor_and_lin2circ(ms, msout='.', dysco=True, beam=True, lin2circ=False,
         cmddppp = 'DP3 numthreads=' + str(multiprocessing.cpu_count()) + ' msin=' + ms + ' msin.datacolumn=DATA '
         cmddppp += 'msout=' + msout + ' '
         cmddppp += 'msin.weightcolumn=WEIGHT_SPECTRUM '
+        if check_phaseup_station(ms): cmddppp += 'msout.uvwcompression=False '
         if msout == '.':
             cmddppp += 'msout.datacolumn=CORRECTED_DATA '
         if (lin2circ or circ2lin) and beam:
@@ -8841,6 +8846,7 @@ def beamcor_and_lin2circ(ms, msout='.', dysco=True, beam=True, lin2circ=False,
     else:
         cmd = 'DP3 numthreads=' + str(multiprocessing.cpu_count()) + ' msin=' + ms + ' msin.datacolumn=DATA '
         cmd += 'msout=' + msout + ' '
+        if check_phaseup_station(ms): cmd += 'msout.uvwcompression=False '
         cmd += 'msin.weightcolumn=WEIGHT_SPECTRUM '
         if msout == '.':
             cmd += 'msout.datacolumn=CORRECTED_DATA '


### PR DESCRIPTION
The UVW compression in new DP3 versions does not work for data that has been phased-up using the `StationAdder` step. This pull request disables this compression when a phaseup is done.