### PR TITLE
Set exit code to 1 for failed selfcal

### DIFF
--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -9758,7 +9758,7 @@ def makeimage(mslist, imageout, pixsize, imsize, channelsout, niter=100000, robu
         if model_allzero:
             logger.error("All channel maps models were zero: Stopping the selfcal")
             print("All channel maps models were zero: Stopping the selfcal")
-            sys.exit(0)
+            sys.exit(1)
 
         if predict and len(h5list) == 0 and not DDEimaging:
             # We check for DDEimaging to avoid a predict for image000 in a --DDE run


### PR DESCRIPTION
If, during self-calibration, all channel map models are 0 the self-calibration will be stopped. Facetselfcal returns 0 here, which indicates success. The VLBI pipeline will then assume that the self-calibration was successful. Setting the exit status to 1 tells the pipeline that something went wrong, which makes it easier to debug failed runs.