### PR TITLE
Extra fix for DI smoothness factors from #352

### DIFF
--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -12235,7 +12235,7 @@ def runDPPPbase(ms, solint, nchan, parmdb, soltype, uvmin=1.,
 
             groupstr = antennaconstraintstr(antgroup.split(':')[0], antennasms, HBAorLBA, telescope=args['telescope'], useforresetsols=True)
             groupstr_all = groupstr_all + groupstr
-            if np.max(smoothness_factors_float) <= 1.0 or (not args["DDE"]):
+            if np.max(smoothness_factors_float) <= 1.0:
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + antgroup.split(':')[1])
             elif (np.max(smoothness_factors_float) > 1.0) and args["DDE"]:
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \

--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -12241,8 +12241,7 @@ def runDPPPbase(ms, solint, nchan, parmdb, soltype, uvmin=1.,
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \
                                                       str(float(antgroup.split(':')[1])/np.max(smoothness_factors_float)))
             elif (np.max(smoothness_factors_float) > 1.0) and (not args["DDE"]):
-                antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \
-                                                      str(float(antgroup.split(':')[1])/np.max(smoothness_factors_float)))
+                antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + antgroup.split(':')[1])
                   
         if len(groupstr_all) != len(set(groupstr_all)):
             print('There are duplicate antennas in antenna_smoothness_factors, please check your input')
@@ -12256,7 +12255,7 @@ def runDPPPbase(ms, solint, nchan, parmdb, soltype, uvmin=1.,
                                                       + str(1.0/np.max(smoothness_factors_float)))  # add the complement antennas with factor 1.0/maximum smooth
             elif (np.max(smoothness_factors_float) > 1.0) and (not args["DDE"]):
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr_complement)) + ']:'
-                                                      + str(np.max(smoothness_factors_float)))  # add the complement antennas with factor 1.0/maximum smooth
+                                                      + str(np.max(smoothness_factors_float)))  # add the complement antennas with factor maximum smooth
             
         if args["DDE"] and (np.max(smoothness_factors_float) > 1.0): # handle the case where the smoothness factors are larger than 1.0
             if type(SMconstraint) == list:

--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -12240,17 +12240,23 @@ def runDPPPbase(ms, solint, nchan, parmdb, soltype, uvmin=1.,
             elif (np.max(smoothness_factors_float) > 1.0) and args["DDE"]:
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \
                                                       str(float(antgroup.split(':')[1])/np.max(smoothness_factors_float)))
+            elif (np.max(smoothness_factors_float) > 1.0) and (not args["DDE"]):
+                antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \
+                                                      str(float(antgroup.split(':')[1])/np.max(smoothness_factors_float)))
                   
         if len(groupstr_all) != len(set(groupstr_all)):
             print('There are duplicate antennas in antenna_smoothness_factors, please check your input')
             raise Exception('There are duplicate antennas in antenna_smoothness_factors, please check your input')
         groupstr_complement = list(set(groupstr_all) ^ set (antennasms))  # get the complement of the antenna group
         if len(groupstr_complement) > 0: 
-            if (np.max(smoothness_factors_float) <= 1.0) or (not args["DDE"]):
+            if (np.max(smoothness_factors_float) <= 1.0):
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr_complement)) + ']:1.0')  # add the complement antennas with factor 1.0
             elif (np.max(smoothness_factors_float) > 1.0) and args["DDE"]:
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr_complement)) + ']:'
                                                       + str(1.0/np.max(smoothness_factors_float)))  # add the complement antennas with factor 1.0/maximum smooth
+            elif (np.max(smoothness_factors_float) > 1.0) and (not args["DDE"]):
+                antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr_complement)) + ']:'
+                                                      + str(np.max(smoothness_factors_float)))  # add the complement antennas with factor 1.0/maximum smooth
             
         if args["DDE"] and (np.max(smoothness_factors_float) > 1.0): # handle the case where the smoothness factors are larger than 1.0
             if type(SMconstraint) == list:

--- a/facetselfcal/main.py
+++ b/facetselfcal/main.py
@@ -12235,9 +12235,9 @@ def runDPPPbase(ms, solint, nchan, parmdb, soltype, uvmin=1.,
 
             groupstr = antennaconstraintstr(antgroup.split(':')[0], antennasms, HBAorLBA, telescope=args['telescope'], useforresetsols=True)
             groupstr_all = groupstr_all + groupstr
-            if np.max(smoothness_factors_float) <= 1.0:
+            if np.max(smoothness_factors_float) <= 1.0 or (not args["DDE"]):
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + antgroup.split(':')[1])
-            else:
+            elif (np.max(smoothness_factors_float) > 1.0) and args["DDE"]:
                 antenna_smoothness_factors_new.append('[' + ','.join(map(str, groupstr)) + ']:' + \
                                                       str(float(antgroup.split(':')[1])/np.max(smoothness_factors_float)))
                   


### PR DESCRIPTION
This fixes two small issues that my previous run apparently didn't trigger:

- an if statement that I missed which still normalised the factors if > 1
- the initial behaviour was that antennas in the complement were added with smoothness of 1, which for factors > 1 should have been updated to add the maximum smoothness in the list.