### PR TITLE
Replace numpy float_ with float64

### DIFF
--- a/submods/sub_sources_outside_region.py
+++ b/submods/sub_sources_outside_region.py
@@ -108,9 +108,9 @@ def getimsize(image):
         if 'Image-NPix' in line:
             imsizeddf = np.int_(line.split('=')[1])
         elif 'Image-Cell' in line:
-            cellddf = np.float_(line.split('=')[1])
+            cellddf = np.float64(line.split('=')[1])
         elif 'Weight-Robust' in line:
-            robustddf = np.float_(line.split('=')[1])
+            robustddf = np.float64(line.split('=')[1])
 
     if imsizeddf is None:
         print('Could not determine the image size, should have been 20000(?) or 6000(?)')


### PR DESCRIPTION
This fixes a crash in sub_sources_outside_region.py for NumPy versions 2 and up. The usage of `np.float_` results in the following crash:

```
Traceback (most recent call last):
 File "/opt/lofar/pyenv-py3/bin/sub_sources_outside_region", line 10, in <module>
  sys.exit(main())
       ^^^^^^
 File "/opt/lofar/pyenv-py3/lib64/python3.12/site-packages/submods/sub_sources_outside_region.py", line 796, in main
  imagenpix, robust, imagecell = getimsize(fullmask)
                  ^^^^^^^^^^^^^^^^^^^
 File "/opt/lofar/pyenv-py3/lib64/python3.12/site-packages/submods/sub_sources_outside_region.py", line 111, in getimsize
  cellddf = np.float_(line.split('=')[1])
       ^^^^^^^^^
 File "/opt/lofar/pyenv-py3/lib64/python3.12/site-packages/numpy/__init__.py", line 763, in __getattr__
  raise AttributeError(
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```

This PR replaces the `np.float_` with the suggested `np.float64`.